### PR TITLE
Padronização dos Controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,26 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  console.error(publicErrorObject);
+
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors.js";
 
 async function query(queryObject) {
   let client;
@@ -7,9 +8,11 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    console.log("\nErro dentro do catch do database.js:");
-    console.error(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      message: "Erro na conexão com o Banco ou na Query.",
+      cause: error,
+    });
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,12 +1,53 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
 
     this.name = "InternalServerError";
     this.action = "Entre em contato com o suporte.";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ message, cause }) {
+    super(message || "Serviço indisponível no momento.", {
+      cause,
+    });
+
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponível.";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para este endpoint.");
+
+    this.name = "MethodNotAllowedError";
+    this.action =
+      "Verifique se o método HTTP enviado é válido para este endpoint.";
+    this.statusCode = 405;
   }
 
   toJSON() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.5",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2434,6 +2435,12 @@
       "dependencies": {
         "@textlint/ast-node-types": "^14.4.2"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -9233,6 +9240,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10485,6 +10505,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.5",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,49 +1,57 @@
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database.js";
+import { createRouter } from "next-connect";
+import controller from "infra/controller.js";
 
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
-  if (!allowedMethods.includes(request.method)) {
-    return response.status(405).json({
-      error: `Method "${request.method}" not allowed`,
-    });
-  }
+const router = createRouter();
 
+router.get(getHandler);
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+const defaultMigrationOptions = {
+  dryRun: true,
+  dir: resolve("infra", "migrations"),
+  direction: "up",
+  verbose: true,
+  migrationsTable: "pgmigrations",
+};
+
+async function getHandler(request, response) {
   let dbClient;
 
   try {
     dbClient = await database.getNewClient();
 
-    const defaultMigrationOptions = {
-      dbClient: dbClient,
-      dryRun: true,
-      dir: resolve("infra", "migrations"),
-      direction: "up",
-      verbose: true,
-      migrationsTable: "pgmigrations",
-    };
+    const pedingMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+    });
+    return response.status(200).json(pedingMigrations);
+  } finally {
+    await dbClient.end();
+  }
+}
 
-    if (request.method == "GET") {
-      const pedingMigrations = await migrationRunner(defaultMigrationOptions);
-      return response.status(200).json(pedingMigrations);
+async function postHandler(request, response) {
+  let dbClient;
+
+  try {
+    dbClient = await database.getNewClient();
+
+    const migratedMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+      dryRun: false,
+    });
+
+    if (migratedMigrations.length > 0) {
+      return response.status(201).json(migratedMigrations);
     }
 
-    if (request.method == "POST") {
-      const migratedMigrations = await migrationRunner({
-        ...defaultMigrationOptions,
-        dryRun: false,
-      });
-
-      if (migratedMigrations.length > 0) {
-        return response.status(201).json(migratedMigrations);
-      }
-
-      return response.status(200).json(migratedMigrations);
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
+    return response.status(200).json(migratedMigrations);
   } finally {
     await dbClient.end();
   }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,44 +1,39 @@
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors.js";
+import controller from "infra/controller.js";
 
-async function status(request, response) {
-  try {
-    const updatedAt = new Date().toISOString();
+const router = createRouter();
 
-    const postgresVersionResult = await database.query("SHOW server_version;");
-    const postgresVersion = postgresVersionResult.rows[0].server_version;
+router.get(getHandler);
 
-    const postgresMaxConnectionsResult = await database.query(
-      "SHOW max_connections;",
-    );
-    const maxConnections = postgresMaxConnectionsResult.rows[0].max_connections;
+export default router.handler(controller.errorHandlers);
 
-    const databaseName = process.env.POSTGRES_DB;
-    const postgresOpenedConnectionsResult = await database.query({
-      text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
-      values: [databaseName],
-    });
-    const openedConnections = postgresOpenedConnectionsResult.rows[0].count;
+async function getHandler(request, response) {
+  const updatedAt = new Date().toISOString();
 
-    response.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version: postgresVersion,
-          max_connections: parseInt(maxConnections),
-          opened_connections: openedConnections,
-        },
+  const postgresVersionResult = await database.query("SHOW server_version;");
+  const postgresVersion = postgresVersionResult.rows[0].server_version;
+
+  const postgresMaxConnectionsResult = await database.query(
+    "SHOW max_connections;",
+  );
+  const maxConnections = postgresMaxConnectionsResult.rows[0].max_connections;
+
+  const databaseName = process.env.POSTGRES_DB;
+  const postgresOpenedConnectionsResult = await database.query({
+    text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
+    values: [databaseName],
+  });
+  const openedConnections = postgresOpenedConnectionsResult.rows[0].count;
+
+  response.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: postgresVersion,
+        max_connections: parseInt(maxConnections),
+        opened_connections: openedConnections,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-    console.log("\nErro dentro do catch do controller:");
-    console.error(publicErrorObject);
-
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }
-
-export default status;

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,26 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os endpoints `/migrations` e `/status` utilizando o `next-connect`.
2. Adiciona 2 novos erros customizados no `errors.js`: `MethodNotAllowedError` e `ServiceError`.
3. Faz o `InternalServerError` aceitar injeção de `statusCode`.

 